### PR TITLE
Add a `getInitialMessage` method to accomplish deep-linking from a Push Notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This is the comparison table of functions implemented within this plugin accordi
 | [getDeviceInterests](https://pub.dev/documentation/pusher_beams/latest/pusher_beams/PusherBeams/getDeviceInterests.html)   | ✅   | ✅       | ✅   |
 | [onInterestChanges](https://pub.dev/documentation/pusher_beams/latest/pusher_beams/PusherBeams/onInterestChanges.html)    | ✅   | ✅       | ⬜️   |
 | [onMessageReceivedInTheForeground](https://pub.dev/documentation/pusher_beams/latest/pusher_beams/PusherBeams/onMessageReceivedInTheForeground.html)    | ✅   | ✅       | ⬜️   |
+| [getInitialMessage](https://pub.dev/documentation/pusher_beams/latest/pusher_beams/PusherBeams/getInitialMessage.html)    | ✅   | ✅       | ⬜️   |
 | [removeDeviceInterest](https://pub.dev/documentation/pusher_beams/latest/pusher_beams/PusherBeams/removeDeviceInterest.html) | ✅   | ✅       | ✅   |
 | [setDeviceInterests](https://pub.dev/documentation/pusher_beams/latest/pusher_beams/PusherBeams/setDeviceInterests.html)   | ✅   | ✅       | ✅   |
 | [setUserId](https://pub.dev/documentation/pusher_beams/latest/pusher_beams/PusherBeams/setUserId.html)            | ✅   | ✅       | ⬜️   |

--- a/packages/pusher_beams/README.md
+++ b/packages/pusher_beams/README.md
@@ -53,6 +53,7 @@ This is the comparison table of functions implemented within this plugin accordi
 | [getDeviceInterests](https://pub.dev/documentation/pusher_beams/latest/pusher_beams/PusherBeams/getDeviceInterests.html)   | ✅   | ✅       | ✅   |
 | [onInterestChanges](https://pub.dev/documentation/pusher_beams/latest/pusher_beams/PusherBeams/onInterestChanges.html)    | ✅   | ✅       | ⬜️   |
 | [onMessageReceivedInTheForeground](https://pub.dev/documentation/pusher_beams/latest/pusher_beams/PusherBeams/onMessageReceivedInTheForeground.html)    | ✅   | ✅       | ⬜️   |
+| [getInitialMessage](https://pub.dev/documentation/pusher_beams/latest/pusher_beams/PusherBeams/getInitialMessage.html)    | ✅   | ✅       | ⬜️   |
 | [removeDeviceInterest](https://pub.dev/documentation/pusher_beams/latest/pusher_beams/PusherBeams/removeDeviceInterest.html) | ✅   | ✅       | ✅   |
 | [setDeviceInterests](https://pub.dev/documentation/pusher_beams/latest/pusher_beams/PusherBeams/setDeviceInterests.html)   | ✅   | ✅       | ✅   |
 | [setUserId](https://pub.dev/documentation/pusher_beams/latest/pusher_beams/PusherBeams/setUserId.html)            | ✅   | ✅       | ⬜️   |

--- a/packages/pusher_beams/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/pusher_beams/example/android/app/src/main/AndroidManifest.xml
@@ -9,7 +9,8 @@
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
-            android:windowSoftInputMode="adjustResize">
+            android:windowSoftInputMode="adjustResize"
+            android:exported="true">
             <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user
                  while the Flutter UI initializes. After that, this theme continues

--- a/packages/pusher_beams/example/lib/main.dart
+++ b/packages/pusher_beams/example/lib/main.dart
@@ -1,13 +1,12 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-
 import 'package:pusher_beams/pusher_beams.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  await PusherBeams.instance
-      .start('your-instance-id'); // Supply your own instanceId
+  await PusherBeams.instance.start(
+      'your-instance-id'); // Supply your own instanceId
 
   runApp(const MyApp());
 }
@@ -69,6 +68,14 @@ class _MyHomePageState extends State<MyHomePage> {
 
       await PusherBeams.instance
           .onMessageReceivedInTheForeground(_onMessageReceivedInTheForeground);
+    }
+    await _checkForInitialMessage();
+  }
+
+  Future<void> _checkForInitialMessage() async {
+    final initialMessage = await PusherBeams.instance.getInitialMessage();
+    if (initialMessage != null) {
+      _showAlert('Initial Message Is:', initialMessage.toString());
     }
   }
 

--- a/packages/pusher_beams/lib/pusher_beams.dart
+++ b/packages/pusher_beams/lib/pusher_beams.dart
@@ -41,6 +41,28 @@ class PusherBeams extends PusherBeamsPlatform with CallbackHandlerApi {
   /// }
   /// ```
   ///
+  /// In order to receive data you need to send the pusher message in the
+  /// following format:
+  ///
+  /// ```json
+  /// {
+  ///   "interests":["hello"],
+  ///   "apns": {
+  ///     "aps": {
+  ///       "alert": {"title":"Hello", "body":"Hello, world!"},
+  ///     },
+  ///    "data": {
+  ///       "info": { "name": "george" }
+  ///     }
+  ///   },
+  ///   "fcm": {
+  ///     "notification": {"title":"Hello", "body":"Hello, world!"},
+  ///     "data": {
+  ///       "info": { "name": "george" }
+  ///     }
+  ///   }
+  /// }
+  /// ```
   /// Throws an [Exception] in case of failure.
   @override
   Future<Map<String, dynamic>?> getInitialMessage() async {

--- a/packages/pusher_beams/lib/pusher_beams.dart
+++ b/packages/pusher_beams/lib/pusher_beams.dart
@@ -30,6 +30,23 @@ class PusherBeams extends PusherBeamsPlatform with CallbackHandlerApi {
   /// This is intended to be a singleton
   static PusherBeams get instance => _instance;
 
+  /// Gets any data associated to a Push Notification when opening the app by
+  /// taping on it.
+  ///
+  /// ## Example Usage
+  ///
+  /// ```dart
+  /// function someAsyncFunction() async {
+  ///   final message = await PusherBeams.instance.getInitialMessage();
+  /// }
+  /// ```
+  ///
+  /// Throws an [Exception] in case of failure.
+  @override
+  Future<Map<String, dynamic>?> getInitialMessage() async {
+    return await _pusherBeamsApi.getInitialMessage();
+  }
+
   /// Adds an [interest] in this device.
   ///
   /// ## Example Usage

--- a/packages/pusher_beams_ios/ios/Classes/messages.h
+++ b/packages/pusher_beams_ios/ios/Classes/messages.h
@@ -22,6 +22,7 @@ NSObject<FlutterMessageCodec> *PusherBeamsApiGetCodec(void);
 
 @protocol PusherBeamsApi
 - (void)startInstanceId:(NSString *)instanceId error:(FlutterError *_Nullable *_Nonnull)error;
+- (void)getInitialMessageWithCompletion:(void(^)(NSDictionary<NSString *, NSObject *> *_Nullable, FlutterError *_Nullable))completion;
 - (void)addDeviceInterestInterest:(NSString *)interest error:(FlutterError *_Nullable *_Nonnull)error;
 - (void)removeDeviceInterestInterest:(NSString *)interest error:(FlutterError *_Nullable *_Nonnull)error;
 - (nullable NSArray<NSString *> *)getDeviceInterestsWithError:(FlutterError *_Nullable *_Nonnull)error;

--- a/packages/pusher_beams_ios/ios/Classes/messages.m
+++ b/packages/pusher_beams_ios/ios/Classes/messages.m
@@ -77,8 +77,7 @@ static NSDictionary<NSString *, id> *wrapResult(id result, FlutterError *error) 
   if ([value isKindOfClass:[BeamsAuthProvider class]]) {
     [self writeByte:128];
     [self writeValue:[value toMap]];
-  } else 
-{
+  } else {
     [super writeValue:value];
   }
 }
@@ -121,6 +120,24 @@ void PusherBeamsApiSetup(id<FlutterBinaryMessenger> binaryMessenger, NSObject<Pu
         FlutterError *error;
         [api startInstanceId:arg_instanceId error:&error];
         callback(wrapResult(nil, error));
+      }];
+    }
+    else {
+      [channel setMessageHandler:nil];
+    }
+  }
+  {
+    FlutterBasicMessageChannel *channel =
+      [FlutterBasicMessageChannel
+        messageChannelWithName:@"dev.flutter.pigeon.PusherBeamsApi.getInitialMessage"
+        binaryMessenger:binaryMessenger
+        codec:PusherBeamsApiGetCodec()];
+    if (api) {
+      NSCAssert([api respondsToSelector:@selector(getInitialMessageWithCompletion:)], @"PusherBeamsApi api (%@) doesn't respond to @selector(getInitialMessageWithCompletion:)", api);
+      [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
+        [api getInitialMessageWithCompletion:^(NSDictionary<NSString *, NSObject *> *_Nullable output, FlutterError *_Nullable error) {
+          callback(wrapResult(output, error));
+        }];
       }];
     }
     else {

--- a/packages/pusher_beams_platform_interface/lib/method_channel_pusher_beams.dart
+++ b/packages/pusher_beams_platform_interface/lib/method_channel_pusher_beams.dart
@@ -96,6 +96,32 @@ class PusherBeamsApi extends PusherBeamsPlatform {
     }
   }
 
+  Future<Map<String, dynamic>?> getInitialMessage() async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.PusherBeamsApi.getInitialMessage', codec,
+        binaryMessenger: _binaryMessenger);
+    final Map<Object?, Object?>? replyMap =
+        await channel.send(null) as Map<Object?, Object?>?;
+    if (replyMap == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+        details: null,
+      );
+    } else if (replyMap['error'] != null) {
+      final Map<Object?, Object?> error =
+          (replyMap['error'] as Map<Object?, Object?>?)!;
+      throw PlatformException(
+        code: (error['code'] as String?)!,
+        message: error['message'] as String?,
+        details: error['details'],
+      );
+    } else {
+      return (replyMap['result'] as Map<Object?, Object?>?)
+          ?.cast<String, dynamic>();
+    }
+  }
+
   Future<void> addDeviceInterest(String arg_interest) async {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
         'dev.flutter.pigeon.PusherBeamsApi.addDeviceInterest', codec,

--- a/packages/pusher_beams_platform_interface/lib/pusher_beams_platform_interface.dart
+++ b/packages/pusher_beams_platform_interface/lib/pusher_beams_platform_interface.dart
@@ -1,6 +1,5 @@
 library pusher_beams_platform_interface;
 
-import 'package:flutter/foundation.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:pusher_beams_platform_interface/method_channel_pusher_beams.dart';
 
@@ -13,7 +12,8 @@ abstract class PusherBeamsPlatform extends PlatformInterface {
 
   static final Object _token = Object();
 
-  // NOTE: Remember to change .onInterestChanges, .setUserId and .onMessageReceivedInTheForeground last argument to dynamic on MethodChannel
+  // NOTE: Remember to change .onInterestChanges and .setUserId last argument
+  // and .getInitialMessage return type to dynamic on MethodChannel
   static PusherBeamsPlatform _instance = PusherBeamsApi();
 
   /// The default instance of [PusherBeamsPlatform] to use.
@@ -31,6 +31,10 @@ abstract class PusherBeamsPlatform extends PlatformInterface {
 
   Future<void> start(String instanceId) {
     throw UnimplementedError('start() has not been implemented.');
+  }
+
+  Future<dynamic> getInitialMessage() {
+    throw UnimplementedError('getInitialMessage() has not been implemented.');
   }
 
   Future<void> addDeviceInterest(String interest) {

--- a/packages/pusher_beams_platform_interface/pigeons/messages.dart
+++ b/packages/pusher_beams_platform_interface/pigeons/messages.dart
@@ -11,6 +11,9 @@ class BeamsAuthProvider {
 abstract class PusherBeamsApi {
   void start(String instanceId);
 
+  @async
+  Map<String, dynamic> getInitialMessage();
+
   void addDeviceInterest(String interest);
 
   void removeDeviceInterest(String interest);


### PR DESCRIPTION
The inspiration for this method comes from Firebase's [`getInitialMessage`](https://pub.dev/documentation/firebase_messaging/latest/firebase_messaging/FirebaseMessaging/getInitialMessage.html). It is a good way to accomplish deep-linking from a Push Notification.

For example, I want to send a push notification to the users of a chatroom, that a new message was posted. I would also like for my users to be navigated to that chatroom when they tap on the notification. With this implementation, I can add data that can be used by my app to do the navigation, in the Push Notification message inside the `data` part of it.

**TLDR;**
Send this message via pusher:
```json
{
  "interests": ["hello"],
  "apns": {
    "aps": {
      "alert": {"title":"Hello", "body":"Hello, world!"}
    },
   "data": {
      "info": { "name": "george" }
    }
  },
  "fcm": {
    "notification": {"title":"Hello", "body":"Hello, world!"}
    "data": {
      "info": { "name": "george" }
    }
  }
}
```
And you can get it if the user opens the app by tapping on the notification:
```dart
final message = await PusherBeams.instance.getInitialMessage(); //{ "name": "george" }
if(message != null) {
  _navigate(message);
}
```

_We already use this patch in our production app, it would be nice to switch back to the official version_