### PR TITLE
fix: Add namespace for AGP 8.0+ compatibility

### DIFF
--- a/packages/pusher_beams_android/android/build.gradle
+++ b/packages/pusher_beams_android/android/build.gradle
@@ -25,6 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'com.pusher.pusher_beams'
     compileSdkVersion 31
 
     compileOptions {


### PR DESCRIPTION
## Summary
- Adds `namespace` declaration to `pusher_beams_android` for Android Gradle Plugin 8.0+ compatibility

## Problem
Starting with AGP 8.0, the `namespace` property must be declared in `build.gradle` rather than relying on the `package` attribute in `AndroidManifest.xml`. Without this, builds fail with:

```
Namespace not specified. Specify a namespace in the module's build file.
```


## Solution
Added `namespace 'com.pusher.pusher_beams'` to the `android` block in `packages/pusher_beams_android/android/build.gradle`.

## Fixes
- Fixes #58 
- Fixes #60 
- Fixes #61 
